### PR TITLE
Fix指定BUILD_DIR时编译错误

### DIFF
--- a/spl/Makefile
+++ b/spl/Makefile
@@ -155,7 +155,7 @@ ifdef CONFIG_SAMSUNG
 $(obj)$(BOARD)-spl.bin: $(obj)u-boot-spl.bin
 	$(OBJTREE)/tools/mk$(SOC)spl \
 		$(obj)u-boot-spl.bin $(obj)$(BOARD)-spl.bin
-	cat $(obj)$(BOARD)-spl.bin $(TOPDIR)/u-boot.bin > $(TOPDIR)/$(BOARD)v2-uboot.bin
+	cat $(obj)$(BOARD)-spl.bin $(OBJTREE)/u-boot.bin > $(OBJTREE)/$(BOARD)v2-uboot.bin
 endif
 
 $(obj)u-boot-spl.bin:	$(obj)u-boot-spl


### PR DESCRIPTION
修复指定obj输出目录时(如make O=./build )，cat合并bin不成功.
若不指定BUILD_DIR则和原来一致，结果输出到TOPDIR。否则结果保存到BUILD_DIR下
