### PR TITLE
BL1: Update Makefile

### DIFF
--- a/BL1/Makefile
+++ b/BL1/Makefile
@@ -1,9 +1,9 @@
-
 CONFIG_SYS_TEXT_BASE :=0x23E00000
 COPY_BL2_SIZE :=0x50000
 
-CFLAGS=-DCONFIG_SYS_TEXT_BASE=$(CONFIG_SYS_TEXT_BASE) \
+CFLAGS+=-DCONFIG_SYS_TEXT_BASE=$(CONFIG_SYS_TEXT_BASE) \
 		-DCOPY_BL2_SIZE=$(COPY_BL2_SIZE)
+		-fno-stack-protector
 
 all:bl1.bin
 	gcc mkv210_image.c -o mkv210
@@ -11,15 +11,15 @@ all:bl1.bin
 	cat ./tiny210v2-bl1.bin ../u-boot.bin > ../tiny210v2-uboot.bin
 
 bl1.bin: start.o nand_cp.o mmc_cp.o clock.o uart.o memory.o stdio.o printf.o
-	@arm-linux-ld -Ttext 0xd0020010 -Tstdio.lds -o bl1.elf $^
-	@arm-linux-objcopy -O binary bl1.elf bl1.bin
-	@arm-linux-objdump -D bl1.elf > bl1_elf.dis
+	@$(CROSS_COMPILE)ld -Ttext 0xd0020010 -Tstdio.lds -o bl1.elf $^
+	@$(CROSS_COMPILE)objcopy -O binary bl1.elf bl1.bin
+	@$(CROSS_COMPILE)objdump -D bl1.elf > bl1_elf.dis
 	
 %.o : %.S
-	@arm-linux-gcc $(CFLAGS) -o $@ $< -c -fno-builtin
+	@$(CROSS_COMPILE)gcc $(CFLAGS) -o $@ $< -c -fno-builtin
 
 %.o : %.c
-	@arm-linux-gcc $(CFLAGS) -o $@ $< -c -fno-builtin
+	@$(CROSS_COMPILE)gcc $(CFLAGS) -o $@ $< -c -fno-builtin
 
 clean  distclean:
 	@rm *.o *.elf *.dis mkv210 *.bin -f


### PR DESCRIPTION
Without fno-stack-protector flag it doesn`t build with default ubuntu 13.04 arm-toolchain. 
CROSS_COMPILE is better solution then hardcoded "arm-linux-".
